### PR TITLE
fix uart problem on debug build.

### DIFF
--- a/src/sysctl.zen
+++ b/src/sysctl.zen
@@ -1,7 +1,7 @@
 
 pub const SYSCTL_BASE_ADDR: usize = 0x50440000;
 
-pub const SysCtl = packed struct {
+pub const SysCtl = extern struct {
     const Self = @This();
 
     git_id: u32, //なんぞこれ


### PR DESCRIPTION
The root cause of this problem is alignment of sysctl structure.
the alignment of packed structure is 1, however sysctl  needs 4(32bit) to the register access.